### PR TITLE
Fix package typo

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5754,9 +5754,9 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-boostrap@^2.0.0:
+bootstrap@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/boostrap/-/boostrap-2.0.0.tgz#f0a5256bc379c5da540564389e48e85e9ccff9fc"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-2.0.0.tgz#f0a5256bc379c5da540564389e48e85e9ccff9fc"
   integrity sha512-JEeFMOweKeGXEM9rt95eaVISOkluG9aKcl0jQCETOVH9jynCZxuBZe2oWgcWJpj5wqYWZl625SnW7OgHT2Ineg==
 
 bootstrap@^5.1.1:


### PR DESCRIPTION
## Summary
- fix lockfile package name `boostrap` -> `bootstrap`

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68482e3eebc4832d8ba41f8be177649c