### PR TITLE
Fix Signer type mismatch in Validators page

### DIFF
--- a/src/pages/validators/Validators.tsx
+++ b/src/pages/validators/Validators.tsx
@@ -66,7 +66,7 @@ const Validators = (): JSX.Element => {
     const api = provider.api as ApiPromise;
     await api.tx.staking
       .nominate([address])
-      .signAndSend(selectedSigner.address, { signer: selectedSigner.signer });
+      .signAndSend(selectedSigner.address, { signer: selectedSigner.sign });
   };
 
   const unbond = async (): Promise<void> => {
@@ -74,7 +74,7 @@ const Validators = (): JSX.Element => {
     const api = provider.api as ApiPromise;
     await api.tx.staking
       .unbond(new BN(0))
-      .signAndSend(selectedSigner.address, { signer: selectedSigner.signer });
+      .signAndSend(selectedSigner.address, { signer: selectedSigner.sign });
   };
 
   return (


### PR DESCRIPTION
## Summary
- use the injected `sign` property instead of the EVM `signer` when calling `signAndSend`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c0cf6408832d9d8ff19d6afb1ada