### PR TITLE
Fix bootstrap dependency name

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@web3modal/standalone": "^2.4.3",
     "axios": "^1.6.7",
     "bignumber.js": "^9.1.2",
-    "boostrap": "^2.0.0",
+    "bootstrap": "^5.1.1",
     "crypto-browserify": "^3.12.0",
     "d3-dsv": "^3.0.1",
     "date-fns": "^2.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5754,11 +5754,6 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-boostrap@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/boostrap/-/boostrap-2.0.0.tgz#f0a5256bc379c5da540564389e48e85e9ccff9fc"
-  integrity sha512-JEeFMOweKeGXEM9rt95eaVISOkluG9aKcl0jQCETOVH9jynCZxuBZe2oWgcWJpj5wqYWZl625SnW7OgHT2Ineg==
-
 bootstrap@^5.1.1:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.3.tgz#de35e1a765c897ac940021900fcbb831602bac38"


### PR DESCRIPTION
## Summary
- fix typo: use `bootstrap@^5.1.1` dependency
- clean yarn.lock entry for mistaken `boostrap`

## Testing
- `yarn test`
- `yarn lint` *(fails: 92 errors, 69 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684c43001f80832d9e49ab41c74ebbc1