### PR TITLE
Show available and staked balances on dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { ReefSigner, defaultOptions, hooks } from '@reef-chain/react-lib';
+import { SignerWithLocked } from './types/SignerWithLocked';
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { toast, ToastContainer } from 'react-toastify';
@@ -61,8 +62,8 @@ export const connectWalletConnect = async(ident:string,setSelExtensionName:any,s
 const App = (): JSX.Element => {
   const {selExtensionName,setSelExtensionName} = useConnectedWallet();
   const {loading:wcPreloader,setLoading:setWcPreloader} = useWcPreloader()
-  const [accounts,setAccounts] = useState<ReefSigner[]>([]);
-  const [selectedSigner,setSelectedSigner] = useState<ReefSigner | undefined>(undefined);
+  const [accounts,setAccounts] = useState<SignerWithLocked[]>([]);
+  const [selectedSigner,setSelectedSigner] = useState<SignerWithLocked | undefined>(undefined);
 
  
   const {
@@ -73,35 +74,34 @@ const App = (): JSX.Element => {
 
   const accountsBalances = hooks.useObservableState(reefState.accounts$);
 
-  useEffect(()=>{
-    let updatedAccountsList:any = []
-    if(signers && accountsBalances){
-      signers.forEach((sgnr,idx)=>{
-        let accountUpdatedBal = {
+  useEffect(() => {
+    const updatedAccountsList: SignerWithLocked[] = [];
+    if (signers && accountsBalances) {
+      signers.forEach((sgnr, idx) => {
+        updatedAccountsList.push({
           ...sgnr,
-          freeBalance: accountsBalances[idx].freeBalance?? BigNumber.from("0"),
-          lockedBalance:accountsBalances[idx].lockedBalance?? BigNumber.from("0")
-        }
-        updatedAccountsList.push(accountUpdatedBal);
-      })
-    
+          freeBalance: accountsBalances[idx].freeBalance ?? BigNumber.from('0'),
+          lockedBalance: accountsBalances[idx].lockedBalance ?? BigNumber.from('0'),
+        });
+      });
       setAccounts(updatedAccountsList);
+      if (selectedReefSigner) {
+        const found = updatedAccountsList.find((acc) => acc.address === selectedReefSigner.address);
+        if (found) setSelectedSigner(found);
+      }
     }
-  },[accountsBalances,signers])
+  }, [accountsBalances, signers, selectedReefSigner]);
 
   useEffect(()=>{
     setAccounts([]);
     setSelectedSigner(undefined);
   },[selExtensionName])
 
-  useEffect(()=>{
-    setSelectedSigner(selectedReefSigner);
-
-    // if account connected , hide preloader & set account address
-    if(signers?.length && signers?.indexOf(selectedReefSigner!)==-1){
-      reefState.setSelectedAddress(signers[0].address)
+  useEffect(() => {
+    if (selectedReefSigner && signers?.length && signers.indexOf(selectedReefSigner) === -1) {
+      reefState.setSelectedAddress(signers[0].address);
     }
-  },[selectedReefSigner,signers])
+  }, [selectedReefSigner, signers]);
 
   const history = useHistory();
   const [isBalanceHidden, setBalanceHidden] = useState(getStoredPref());

--- a/src/context/ReefSigners.ts
+++ b/src/context/ReefSigners.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { ReefSigner } from '@reef-chain/react-lib';
+import { SignerWithLocked } from '../types/SignerWithLocked';
 import { network as nw, extension as extReef } from '@reef-chain/util-lib';
 import { Provider } from '@reef-chain/evm-provider';
 import { Observable } from 'rxjs';
@@ -25,8 +25,8 @@ export interface ReefState {
 }
 
 interface ReefSignersContext {
-  accounts: ReefSigner[]|undefined;
-  selectedSigner:ReefSigner|undefined;
+  accounts: SignerWithLocked[]|undefined;
+  selectedSigner: SignerWithLocked|undefined;
   network: nw.Network;
   provider: Provider|undefined;
   reefState: ReefState;

--- a/src/pages/dashboard/Balance.tsx
+++ b/src/pages/dashboard/Balance.tsx
@@ -104,7 +104,10 @@ export const Balance = ({
           {loading ? (
             <Uik.Loading size="small" />
           ) : (
-            <Uik.Text type="headline" className="dashboard__sub-balance-value">
+            <Uik.Text
+              type="headline"
+              className={`dashboard__sub-balance-value ${isHidden ? 'dashboard__balance-value--hidden' : ''}`}
+            >
               {isHidden ? (
                 <>
                   <div />
@@ -124,7 +127,10 @@ export const Balance = ({
           {loading ? (
             <Uik.Loading size="small" />
           ) : (
-            <Uik.Text type="headline" className="dashboard__sub-balance-value">
+            <Uik.Text
+              type="headline"
+              className={`dashboard__sub-balance-value ${isHidden ? 'dashboard__balance-value--hidden' : ''}`}
+            >
               {isHidden ? (
                 <>
                   <div />

--- a/src/pages/dashboard/Balance.tsx
+++ b/src/pages/dashboard/Balance.tsx
@@ -4,10 +4,11 @@ import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import { toCurrencyFormat } from '../../utils/utils';
 import HideBalance from '../../context/HideBalance';
 import { displayBalance } from '../../utils/displayBalance';
-import { localizedStrings } from '../../l10n/l10n';
 
 interface Balance {
-  balance: number;
+  total: number;
+  available: number;
+  staked: number;
   loading: boolean;
   className?: string;
 }
@@ -24,19 +25,25 @@ export const Loading = (): JSX.Element => (
 );
 
 export const Balance = ({
-  balance,
+  total,
+  available,
+  staked,
   loading,
   className,
 }: Balance): JSX.Element => {
   const { isHidden, toggle } = useContext(HideBalance);
 
-  const getBalance = useMemo((): string => {
-    if (balance >= 1000000) {
-      return `$${displayBalance(balance)}`;
+  const getTotal = useMemo((): string => {
+    if (total >= 1000000) {
+      return `$${displayBalance(total)}`;
     }
 
-    return toCurrencyFormat(balance as number, { maximumFractionDigits: balance < 10000 ? 2 : 0 });
-  }, [balance]);
+    return toCurrencyFormat(total as number, { maximumFractionDigits: total < 10000 ? 2 : 0 });
+  }, [total]);
+
+  const getAvailable = useMemo((): string => toCurrencyFormat(available, { maximumFractionDigits: available < 10000 ? 2 : 0 }), [available]);
+
+  const getStaked = useMemo((): string => toCurrencyFormat(staked, { maximumFractionDigits: staked < 10000 ? 2 : 0 }), [staked]);
 
   const toggleHidden = (): void => {
     if (isHidden) toggle();
@@ -49,7 +56,7 @@ export const Balance = ({
     `}
     >
       <div className="dashboard__balance-label">
-        <Uik.Text type="lead">{localizedStrings.balance}</Uik.Text>
+        <Uik.Text type="lead">Total</Uik.Text>
         <button
           key={String(isHidden)}
           type="button"
@@ -63,7 +70,7 @@ export const Balance = ({
         </button>
       </div>
       {
-        loading || getBalance === 'US$NaN' ? <Loading />
+        loading || getTotal === 'US$NaN' ? <Loading />
           : (
             <button
               type="button"
@@ -85,11 +92,23 @@ export const Balance = ({
                       <div />
                     </>
                   )
-                  : getBalance
+                  : getTotal
               }
             </button>
           )
       }
+      <div className="dashboard__balance-sub">
+        <div className="dashboard__balance-item">
+          <Uik.Text type="lead">Available</Uik.Text>
+          {loading ? <Uik.Loading size="small" />
+            : <Uik.Text type="title">{isHidden ? '***' : getAvailable}</Uik.Text>}
+        </div>
+        <div className="dashboard__balance-item">
+          <Uik.Text type="lead">Staked</Uik.Text>
+          {loading ? <Uik.Loading size="small" />
+            : <Uik.Text type="title">{isHidden ? '***' : getStaked}</Uik.Text>}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/dashboard/Balance.tsx
+++ b/src/pages/dashboard/Balance.tsx
@@ -101,13 +101,23 @@ export const Balance = ({
       <div className="dashboard__balance-sub">
         <div className="dashboard__balance-item">
           <Uik.Text type="lead">Available</Uik.Text>
-          {loading ? <Uik.Loading size="small" />
-            : <Uik.Text type="headline">{isHidden ? '***' : getAvailable}</Uik.Text>}
+          {loading ? (
+            <Uik.Loading size="small" />
+          ) : (
+            <Uik.Text type="headline" className="dashboard__sub-balance-value">
+              {isHidden ? '***' : getAvailable}
+            </Uik.Text>
+          )}
         </div>
         <div className="dashboard__balance-item">
           <Uik.Text type="lead">Staked</Uik.Text>
-          {loading ? <Uik.Loading size="small" />
-            : <Uik.Text type="headline">{isHidden ? '***' : getStaked}</Uik.Text>}
+          {loading ? (
+            <Uik.Loading size="small" />
+          ) : (
+            <Uik.Text type="headline" className="dashboard__sub-balance-value">
+              {isHidden ? '***' : getStaked}
+            </Uik.Text>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/dashboard/Balance.tsx
+++ b/src/pages/dashboard/Balance.tsx
@@ -70,7 +70,8 @@ export const Balance = ({
         </button>
       </div>
       {
-        loading || getTotal === 'US$NaN' ? <Loading />
+        loading || getTotal === 'US$NaN'
+          ? <Loading />
           : (
             <button
               type="button"
@@ -84,7 +85,7 @@ export const Balance = ({
                 isHidden
                   ? (
                     <>
-                      $
+                      <Uik.Text type="headline">$</Uik.Text>
                       <div />
                       <div />
                       <div />
@@ -92,7 +93,7 @@ export const Balance = ({
                       <div />
                     </>
                   )
-                  : getTotal
+                  : <Uik.Text type="headline">{getTotal}</Uik.Text>
               }
             </button>
           )
@@ -101,12 +102,12 @@ export const Balance = ({
         <div className="dashboard__balance-item">
           <Uik.Text type="lead">Available</Uik.Text>
           {loading ? <Uik.Loading size="small" />
-            : <Uik.Text type="title">{isHidden ? '***' : getAvailable}</Uik.Text>}
+            : <Uik.Text type="headline">{isHidden ? '***' : getAvailable}</Uik.Text>}
         </div>
         <div className="dashboard__balance-item">
           <Uik.Text type="lead">Staked</Uik.Text>
           {loading ? <Uik.Loading size="small" />
-            : <Uik.Text type="title">{isHidden ? '***' : getStaked}</Uik.Text>}
+            : <Uik.Text type="headline">{isHidden ? '***' : getStaked}</Uik.Text>}
         </div>
       </div>
     </div>

--- a/src/pages/dashboard/Balance.tsx
+++ b/src/pages/dashboard/Balance.tsx
@@ -105,7 +105,17 @@ export const Balance = ({
             <Uik.Loading size="small" />
           ) : (
             <Uik.Text type="headline" className="dashboard__sub-balance-value">
-              {isHidden ? '***' : getAvailable}
+              {isHidden ? (
+                <>
+                  <div />
+                  <div />
+                  <div />
+                  <div />
+                  <div />
+                </>
+              ) : (
+                getAvailable
+              )}
             </Uik.Text>
           )}
         </div>
@@ -115,7 +125,17 @@ export const Balance = ({
             <Uik.Loading size="small" />
           ) : (
             <Uik.Text type="headline" className="dashboard__sub-balance-value">
-              {isHidden ? '***' : getStaked}
+              {isHidden ? (
+                <>
+                  <div />
+                  <div />
+                  <div />
+                  <div />
+                  <div />
+                </>
+              ) : (
+                getStaked
+              )}
             </Uik.Text>
           )}
         </div>

--- a/src/pages/dashboard/Balance.tsx
+++ b/src/pages/dashboard/Balance.tsx
@@ -1,9 +1,7 @@
 import Uik from '@reef-chain/ui-kit';
 import React, { useContext, useMemo } from 'react';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
-import { toCurrencyFormat } from '../../utils/utils';
 import HideBalance from '../../context/HideBalance';
-import { displayBalance } from '../../utils/displayBalance';
 
 interface Balance {
   total: number;
@@ -33,17 +31,19 @@ export const Balance = ({
 }: Balance): JSX.Element => {
   const { isHidden, toggle } = useContext(HideBalance);
 
-  const getTotal = useMemo((): string => {
-    if (total >= 1000000) {
-      return `$${displayBalance(total)}`;
-    }
+  const formatCompactUSD = (value: number): string => `${
+    Intl.NumberFormat(navigator.language, {
+      notation: 'compact',
+      compactDisplay: 'short',
+      maximumFractionDigits: 2,
+    }).format(value)
+  }$US`;
 
-    return toCurrencyFormat(total as number, { maximumFractionDigits: total < 10000 ? 2 : 0 });
-  }, [total]);
+  const getTotal = useMemo((): string => formatCompactUSD(total), [total]);
 
-  const getAvailable = useMemo((): string => toCurrencyFormat(available, { maximumFractionDigits: available < 10000 ? 2 : 0 }), [available]);
+  const getAvailable = useMemo((): string => formatCompactUSD(available), [available]);
 
-  const getStaked = useMemo((): string => toCurrencyFormat(staked, { maximumFractionDigits: staked < 10000 ? 2 : 0 }), [staked]);
+  const getStaked = useMemo((): string => formatCompactUSD(staked), [staked]);
 
   const toggleHidden = (): void => {
     if (isHidden) toggle();

--- a/src/pages/dashboard/Dashboard.css
+++ b/src/pages/dashboard/Dashboard.css
@@ -464,8 +464,3 @@
     white-space: nowrap;
     overflow: hidden;
 }
-@media (max-width: 480px) {
-    .dashboard__balance-item {
-        flex-basis: 100%;
-    }
-}

--- a/src/pages/dashboard/Dashboard.css
+++ b/src/pages/dashboard/Dashboard.css
@@ -444,8 +444,8 @@
 }
 
 .dashboard__balance-sub {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 8px;
     width: 100%;
     margin-top: 8px;
@@ -454,8 +454,8 @@
 .dashboard__balance-item {
     display: flex;
     flex-direction: column;
-    flex: 1 1 180px;
-    min-width: 150px;
+    align-items: flex-start;
+    min-width: 0;
     overflow: hidden;
 }
 

--- a/src/pages/dashboard/Dashboard.css
+++ b/src/pages/dashboard/Dashboard.css
@@ -442,3 +442,15 @@
     padding-bottom: 0.5em;
     padding-top: 0.8em;
 }
+
+.dashboard__balance-sub {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    margin-top: 8px;
+}
+
+.dashboard__balance-item {
+    display: flex;
+    flex-direction: column;
+}

--- a/src/pages/dashboard/Dashboard.css
+++ b/src/pages/dashboard/Dashboard.css
@@ -457,3 +457,14 @@
     min-width: 0;
     overflow: hidden;
 }
+
+.dashboard__balance-item + .dashboard__balance-item {
+    margin-left: 8px;
+}
+
+.dashboard__sub-balance-value.uik-text--headline {
+    font-size: 2rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/src/pages/dashboard/Dashboard.css
+++ b/src/pages/dashboard/Dashboard.css
@@ -466,5 +466,4 @@
     font-size: 2rem;
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
 }

--- a/src/pages/dashboard/Dashboard.css
+++ b/src/pages/dashboard/Dashboard.css
@@ -454,8 +454,8 @@
 .dashboard__balance-item {
     display: flex;
     flex-direction: column;
-    flex: 1 1 0;
-    min-width: 0;
+    flex: 1 1 180px;
+    min-width: 150px;
     overflow: hidden;
 }
 

--- a/src/pages/dashboard/Dashboard.css
+++ b/src/pages/dashboard/Dashboard.css
@@ -445,7 +445,8 @@
 
 .dashboard__balance-sub {
     display: flex;
-    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 8px;
     width: 100%;
     margin-top: 8px;
 }
@@ -453,17 +454,18 @@
 .dashboard__balance-item {
     display: flex;
     flex-direction: column;
-    flex: 1;
+    flex: 1 1 0;
     min-width: 0;
     overflow: hidden;
-}
-
-.dashboard__balance-item + .dashboard__balance-item {
-    margin-left: 8px;
 }
 
 .dashboard__sub-balance-value.uik-text--headline {
     font-size: 2rem;
     white-space: nowrap;
     overflow: hidden;
+}
+@media (max-width: 480px) {
+    .dashboard__balance-item {
+        flex-basis: 100%;
+    }
 }

--- a/src/pages/dashboard/Dashboard.css
+++ b/src/pages/dashboard/Dashboard.css
@@ -453,4 +453,7 @@
 .dashboard__balance-item {
     display: flex;
     flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
 }

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -1,7 +1,8 @@
 import Uik from '@reef-chain/ui-kit';
 import BigNumber from 'bignumber.js';
 import React, { useContext, useMemo, useState } from 'react';
-import { network as nw, utils } from '@reef-chain/util-lib';
+import { network as nw } from '@reef-chain/util-lib';
+import { utils } from '@reef-chain/react-lib';
 import NftContext from '../../context/NftContext';
 import TokenContext from '../../context/TokenContext';
 import TokenPricesContext from '../../context/TokenPricesContext';
@@ -49,12 +50,12 @@ const Dashboard = (): JSX.Element => {
       new BigNumber(0),
     ).toNumber(), [tokenPrices, tokens]);
 
-  const availableBalance = useMemo(() => new BigNumber(selectedSigner?.freeBalance?.toString() || 0)
+  const availableBalance = useMemo(() => new BigNumber((selectedSigner as any)?.freeBalance?.toString() || 0)
     .div(new BigNumber(10).pow(18))
     .multipliedBy(reefPrice)
     .toNumber() + tokensWithoutReefValue, [reefPrice, selectedSigner, tokensWithoutReefValue]);
 
-  const stakedBalance = useMemo(() => new BigNumber(selectedSigner?.lockedBalance?.toString() || 0)
+  const stakedBalance = useMemo(() => new BigNumber((selectedSigner as any)?.lockedBalance?.toString() || 0)
     .div(new BigNumber(10).pow(18))
     .multipliedBy(reefPrice)
     .toNumber(), [reefPrice, selectedSigner]);

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
 import Uik from '@reef-chain/ui-kit';
 import BigNumber from 'bignumber.js';
 import React, { useContext, useMemo, useState } from 'react';
-import { network as nw } from '@reef-chain/util-lib';
+import { network as nw, utils } from '@reef-chain/util-lib';
 import NftContext from '../../context/NftContext';
 import TokenContext from '../../context/TokenContext';
 import TokenPricesContext from '../../context/TokenPricesContext';
@@ -34,22 +34,39 @@ const Dashboard = (): JSX.Element => {
 
   const [tab, setTab] = useState<string>(tabs[0].value);
 
-  const totalBalance = useMemo(() => tokens.reduce(
-    (acc, { balance, decimals, address }) => acc.plus(
-      new BigNumber(balance.toString())
-        .div(new BigNumber(10).pow(decimals))
-        .multipliedBy(Number.isNaN(+tokenPrices[address]) ? 0 : tokenPrices[address]),
-    ),
-    new BigNumber(0),
-  ).toNumber(),
-  [tokenPrices, tokens]);
+  const { REEF_ADDRESS } = utils;
+
+  const reefPrice = tokenPrices[REEF_ADDRESS] || 0;
+
+  const tokensWithoutReefValue = useMemo(() => tokens
+    .filter(({ address }) => address !== REEF_ADDRESS)
+    .reduce(
+      (acc, { balance, decimals, address }) => acc.plus(
+        new BigNumber(balance.toString())
+          .div(new BigNumber(10).pow(decimals))
+          .multipliedBy(Number.isNaN(+tokenPrices[address]) ? 0 : tokenPrices[address]),
+      ),
+      new BigNumber(0),
+    ).toNumber(), [tokenPrices, tokens]);
+
+  const availableBalance = useMemo(() => new BigNumber(selectedSigner?.freeBalance?.toString() || 0)
+    .div(new BigNumber(10).pow(18))
+    .multipliedBy(reefPrice)
+    .toNumber() + tokensWithoutReefValue, [reefPrice, selectedSigner, tokensWithoutReefValue]);
+
+  const stakedBalance = useMemo(() => new BigNumber(selectedSigner?.lockedBalance?.toString() || 0)
+    .div(new BigNumber(10).pow(18))
+    .multipliedBy(reefPrice)
+    .toNumber(), [reefPrice, selectedSigner]);
+
+  const totalBalance = availableBalance + stakedBalance;
 
   return (
     selectedSigner?
     <div className="dashboard">
       <div className="dashboard__top">
         <div className="dashboard__top-left">
-          <Balance balance={totalBalance} loading={loading} />
+          <Balance total={totalBalance} available={availableBalance} staked={stakedBalance} loading={loading} />
           {/* <Rewards rewards={0} /> */}
         </div>
         <div className="dashboard__top-right">

--- a/src/types/SignerWithLocked.ts
+++ b/src/types/SignerWithLocked.ts
@@ -1,0 +1,7 @@
+import { ReefSigner } from '@reef-chain/react-lib';
+import { BigNumber } from 'ethers';
+
+export interface SignerWithLocked extends ReefSigner {
+  freeBalance: BigNumber;
+  lockedBalance: BigNumber;
+}


### PR DESCRIPTION
## Summary
- compute available, staked and total portfolio values
- display Total, Available and Staked on the dashboard balance widget
- style sub-balance row for new fields

## Testing
- `npm test -- -w=0`

------
https://chatgpt.com/codex/tasks/task_e_684c42726478832db76152e07d08c289