### PR TITLE
Fix balance masking layout

### DIFF
--- a/src/pages/dashboard/Balance.tsx
+++ b/src/pages/dashboard/Balance.tsx
@@ -81,20 +81,17 @@ export const Balance = ({
               `}
               onClick={toggleHidden}
             >
-              {
-                isHidden
-                  ? (
-                    <>
-                      <Uik.Text type="headline">$</Uik.Text>
-                      <div />
-                      <div />
-                      <div />
-                      <div />
-                      <div />
-                    </>
-                  )
-                  : <Uik.Text type="headline">{getTotal}</Uik.Text>
-              }
+              <Uik.Text type="headline" className="dashboard__balance-text">
+                {getTotal}
+              </Uik.Text>
+              <span className="dashboard__balance-mask">
+                <Uik.Text type="headline">$</Uik.Text>
+                <div />
+                <div />
+                <div />
+                <div />
+                <div />
+              </span>
             </button>
           )
       }
@@ -108,17 +105,14 @@ export const Balance = ({
               type="headline"
               className={`dashboard__sub-balance-value ${isHidden ? 'dashboard__balance-value--hidden' : ''}`}
             >
-              {isHidden ? (
-                <>
-                  <div />
-                  <div />
-                  <div />
-                  <div />
-                  <div />
-                </>
-              ) : (
-                getAvailable
-              )}
+              <span className="dashboard__balance-text">{getAvailable}</span>
+              <span className="dashboard__balance-mask">
+                <div />
+                <div />
+                <div />
+                <div />
+                <div />
+              </span>
             </Uik.Text>
           )}
         </div>
@@ -131,17 +125,14 @@ export const Balance = ({
               type="headline"
               className={`dashboard__sub-balance-value ${isHidden ? 'dashboard__balance-value--hidden' : ''}`}
             >
-              {isHidden ? (
-                <>
-                  <div />
-                  <div />
-                  <div />
-                  <div />
-                  <div />
-                </>
-              ) : (
-                getStaked
-              )}
+              <span className="dashboard__balance-text">{getStaked}</span>
+              <span className="dashboard__balance-mask">
+                <div />
+                <div />
+                <div />
+                <div />
+                <div />
+              </span>
             </Uik.Text>
           )}
         </div>

--- a/src/pages/dashboard/Dashboard.css
+++ b/src/pages/dashboard/Dashboard.css
@@ -298,6 +298,9 @@
     font-weight: 900 !important;
     line-height: 1.2;
     font-family: 'Lato', sans-serif;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
 }
 
 .dashboard__balance-value:hover {
@@ -328,17 +331,34 @@
     line-height: 1.25;
     font-family: 'Lato', sans-serif;
 }
-
 .dashboard__balance-value--hidden {
-    display: flex;
-    flex-flow: row nowrap;
-    justify-content: flex-start;
-    align-items: center;
     cursor: pointer;
 }
 
 .dashboard__balance-value--hidden:hover {
     cursor: pointer;
+}
+
+.dashboard__balance-mask {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 0;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    align-items: center;
+}
+
+.dashboard__balance-value--hidden .dashboard__balance-mask {
+    display: flex;
+}
+
+.dashboard__balance-text {
+    display: inline-flex;
+}
+
+.dashboard__balance-value--hidden .dashboard__balance-text {
+    visibility: hidden;
 }
 
 .dashboard__balance-value--hidden div {
@@ -349,6 +369,7 @@
     margin-left: 0.625rem;
     animation: dashboard-balance-hidden-dot 0.15s;
 }
+
 
 .dashboard__rewards-value.dashboard__balance-value--hidden div {
     width: 8px;
@@ -463,4 +484,7 @@
     font-size: 2rem;
     white-space: nowrap;
     overflow: hidden;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
 }

--- a/src/pages/dashboard/Rewards.tsx
+++ b/src/pages/dashboard/Rewards.tsx
@@ -47,20 +47,15 @@ export const Rewards = ({
           `}
         onClick={toggleHidden}
       >
-        {
-            isHidden
-              ? (
-                <>
-                  $
-                  <div />
-                  <div />
-                  <div />
-                  <div />
-                  <div />
-                </>
-              )
-              : getRewards
-          }
+        <span className="dashboard__balance-text">{getRewards}</span>
+        <span className="dashboard__balance-mask">
+          $
+          <div />
+          <div />
+          <div />
+          <div />
+          <div />
+        </span>
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- keep balance text width constant when hiding values
- overlay mask dots rather than replacing balance text
- ensure sub-balance items and rewards use same masking approach

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684c7688c948832da8eaaa67cc63ea40