### PR TITLE
Add tooltip icon to token card

### DIFF
--- a/src/pages/dashboard/TokenBalances.tsx
+++ b/src/pages/dashboard/TokenBalances.tsx
@@ -1,22 +1,23 @@
-import { Token,Components } from '@reef-chain/react-lib';
+import { Token, Components } from '@reef-chain/react-lib';
 import Uik from '@reef-chain/ui-kit';
 import React, { useContext } from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { Link } from 'react-router-dom';
 import BigNumber from 'bignumber.js';
+import { extension as reefExt } from '@reef-chain/util-lib';
 import TokenPricesContext from '../../context/TokenPricesContext';
 import { BUY_URL, CREATE_ERC20_TOKEN_URL } from '../../urls';
 import { localizedStrings } from '../../l10n/l10n';
 import './loading-animation.css';
+import TokenCardWithTooltip from './TokenCardWithTooltip';
 import ReefSigners from '../../context/ReefSigners';
 import { isReefswapUI, useDexConfig } from '../../environment';
 import PoolContext from '../../context/PoolContext';
 import HideBalance from '../../context/HideBalance';
 import useConnectedWallet from '../../hooks/useConnectedWallet';
-import { extension as reefExt } from '@reef-chain/util-lib';
 import useWcPreloader from '../../hooks/useWcPreloader';
 
-const {Skeleton,TokenCard} = Components;
+const { Skeleton } = Components;
 
 interface TokenBalances {
     tokens: Token[];
@@ -40,21 +41,23 @@ const balanceValue = (token: Token, price = 0): number => (new BigNumber(token.b
 
 export const TokenBalances = ({ tokens }: TokenBalances): JSX.Element => {
   const tokenPrices = useContext(TokenPricesContext);
-  const { selectedSigner, network,accounts,provider } = useContext(ReefSigners);
+  const {
+    selectedSigner, network, accounts, provider,
+  } = useContext(ReefSigners);
   const pools = useContext(PoolContext);
-  const hidebalance = useContext(HideBalance)
-  const {selExtensionName} = useConnectedWallet();
-  const {setLoading:setWcPreloader} = useWcPreloader();
+  const hidebalance = useContext(HideBalance);
+  const { selExtensionName } = useConnectedWallet();
+  const { setLoading: setWcPreloader } = useWcPreloader();
   const { walletSelectorOptions } = Components;
 
-  const isWalletConnect = selExtensionName == walletSelectorOptions[reefExt.REEF_WALLET_CONNECT_IDENT].name
+  const isWalletConnect = selExtensionName == walletSelectorOptions[reefExt.REEF_WALLET_CONNECT_IDENT].name;
 
-  const handleWalletConnectModal = (hasStarted:boolean)=>{
-      setWcPreloader({
-value:hasStarted,
-message:"waiting for transaction approval"
-      })
-  }
+  const handleWalletConnectModal = (hasStarted:boolean) => {
+    setWcPreloader({
+      value: hasStarted,
+      message: 'waiting for transaction approval',
+    });
+  };
 
   const isReefBalanceZero = selectedSigner?.balance._hex === '0x00';
 
@@ -85,22 +88,22 @@ message:"waiting for transaction approval"
     })
     .map((token) => (
       <div key={token.address}>
-        <TokenCard
-        accounts={accounts}
-        hideBalance={hidebalance}
-        isReefswapUI={isReefswapUI}
-        nw={network}
-        pools={pools}
-        price={tokenPrices[token.address] || 0}
-        token={token}
-        tokens={tokens}
-        useDexConfig={useDexConfig}
-        provider={provider}
-        selectedSigner={selectedSigner}
-        signer={selectedSigner}
-        tokenPrices={tokenPrices}
-        isWalletConnect={isWalletConnect}
-        handleWalletConnectModal={handleWalletConnectModal}
+        <TokenCardWithTooltip
+          accounts={accounts}
+          hideBalance={hidebalance}
+          isReefswapUI={isReefswapUI}
+          nw={network}
+          pools={pools}
+          price={tokenPrices[token.address] || 0}
+          token={token}
+          tokens={tokens}
+          useDexConfig={useDexConfig}
+          provider={provider}
+          selectedSigner={selectedSigner}
+          signer={selectedSigner}
+          tokenPrices={tokenPrices}
+          isWalletConnect={isWalletConnect}
+          handleWalletConnectModal={handleWalletConnectModal}
         />
       </div>
     ));
@@ -138,7 +141,7 @@ message:"waiting for transaction approval"
                       : (
                         <>
                           {tokenCards}
-                          {tokens.length > 1 && isReefswapUI&&<CreateTokenButton />}
+                          {tokens.length > 1 && isReefswapUI && <CreateTokenButton />}
                         </>
                       )
                   )

--- a/src/pages/dashboard/TokenCardWithTooltip.tsx
+++ b/src/pages/dashboard/TokenCardWithTooltip.tsx
@@ -1,0 +1,88 @@
+import React, { useRef, useEffect } from 'react';
+import { Components, Token, utils } from '@reef-chain/react-lib';
+import Uik from '@reef-chain/ui-kit';
+import { faCoins } from '@fortawesome/free-solid-svg-icons';
+import BigNumber from 'bignumber.js';
+import { toCurrencyFormat } from '../../utils/utils';
+import './token-card-tooltip.css';
+
+const { TokenCard } = Components;
+
+interface Props extends React.ComponentProps<typeof TokenCard> {
+  token: Token;
+}
+
+const formatBalance = (token: Token): number => {
+  try {
+    return new BigNumber(token.balance.toString())
+      .div(new BigNumber(10).pow(token.decimals))
+      .toNumber();
+  } catch {
+    return 0;
+  }
+};
+
+const formatCompact = (value: number): string => {
+  if (value < 1) {
+    const min = value > 0 && value < 0.01 ? 0.01 : value;
+    return new Intl.NumberFormat(
+      navigator.language,
+      {
+        maximumFractionDigits: 2,
+        minimumFractionDigits: value > 0 && value < 0.01 ? 2 : 0,
+      },
+    ).format(min);
+  }
+  return new Intl.NumberFormat(
+    navigator.language,
+    { notation: 'compact', compactDisplay: 'short', maximumFractionDigits: 2 },
+  ).format(value);
+};
+
+const TokenCardWithTooltip = ({ token, ...rest }: Props): JSX.Element => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const iconRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const wrapperEl = wrapperRef.current;
+    const iconEl = iconRef.current;
+    if (!wrapperEl || !iconEl) return;
+    const valuesEl = wrapperEl.querySelector('.token-card__values');
+    if (valuesEl) {
+      valuesEl.insertAdjacentElement('afterend', iconEl);
+    }
+  }, []);
+
+  const balance = formatBalance(token);
+  const price = (rest as any).price || 0;
+
+  const locked = token.address === utils.REEF_ADDRESS
+    ? new BigNumber((rest as any).selectedSigner?.lockedBalance?.toString() || 0)
+      .div(new BigNumber(10).pow(token.decimals))
+      .toNumber()
+    : 0;
+
+  const available = Math.max(balance - locked, 0);
+  const total = available + locked;
+
+  const formatLine = (value: number): string => `${formatCompact(value)} (${toCurrencyFormat(value * price, { maximumFractionDigits: 2 })})`;
+
+  const tooltip = [
+    `Total: ${formatLine(total)}`,
+    `Available: ${formatLine(available)}`,
+    `Staked: ${formatLine(locked)}`,
+  ].join('\n');
+
+  return (
+    <div ref={wrapperRef} className="token-card-tooltip-wrapper">
+      <TokenCard token={token} {...rest} />
+      <div ref={iconRef} className="token-card-tooltip-icon">
+        <Uik.Tooltip text={tooltip} position="bottom">
+          <Uik.Icon icon={faCoins} />
+        </Uik.Tooltip>
+      </div>
+    </div>
+  );
+};
+
+export default TokenCardWithTooltip;

--- a/src/pages/dashboard/token-card-tooltip.css
+++ b/src/pages/dashboard/token-card-tooltip.css
@@ -1,0 +1,18 @@
+.token-card-tooltip-wrapper {
+  position: relative;
+}
+
+.token-card-tooltip-icon {
+  display: flex;
+  align-items: center;
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.token-card-tooltip-wrapper .uik-tooltip__tooltip {
+  z-index: 1000;
+}
+
+.token-card-tooltip-wrapper .uik-tooltip__tooltip-text {
+  white-space: pre-line;
+}


### PR DESCRIPTION
## Summary
- create TokenCardWithTooltip wrapper to show coin icon with tooltip and staked balance
- insert icon between balance values and action buttons in token cards
- format tooltip values vertically using compact number display with USD equivalent
- ensure tooltip overlays page content
- fix tooltip total balance calculation
- show 'Staked' label and improved compact formatting for tiny available amounts

## Testing
- `yarn lint` *(fails: 123 errors)*
- `yarn test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3d155464832db1841475058d41b4