### PR TITLE
Implement local validator caching

### DIFF
--- a/src/utils/validatorsCache.ts
+++ b/src/utils/validatorsCache.ts
@@ -1,0 +1,43 @@
+export interface CachedValidator {
+  address: string;
+  identity?: string;
+  totalBonded: string;
+  commission: string;
+  isActive: boolean;
+}
+
+interface CacheEntry {
+  era: string;
+  validators: CachedValidator[];
+}
+
+export const CACHE_ACTIVE_KEY = 'cached-active-validators';
+export const CACHE_WAITING_KEY = 'cached-waiting-validators';
+
+export const saveValidators = (
+  key: string,
+  era: string,
+  validators: CachedValidator[],
+): void => {
+  try {
+    const data: CacheEntry = { era, validators };
+    localStorage.setItem(key, JSON.stringify(data));
+  } catch (e) {
+    // ignore localStorage errors
+  }
+};
+
+export const loadValidators = (
+  key: string,
+  era: string,
+): CachedValidator[] | null => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CacheEntry;
+    if (parsed.era === era) return parsed.validators;
+  } catch (e) {
+    // ignore parsing errors
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- add a small utilities module to persist validator lists per era
- cache active and waiting validator lists in `Validators` and `WaitingValidators`

## Testing
- `yarn lint` *(fails: 123 errors)*
- `CI=true yarn test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684dedb7af7c832d87ed934134535ecd