### PR TITLE
Update validators stake display

### DIFF
--- a/src/pages/validators/Validators.tsx
+++ b/src/pages/validators/Validators.tsx
@@ -9,8 +9,8 @@ import TokenPricesContext from '../../context/TokenPricesContext';
 import ReefSigners from '../../context/ReefSigners';
 import { VALIDATORS_URL } from '../../urls';
 import { localizedStrings as strings } from '../../l10n/l10n';
-import { formatReefAmount } from '../../utils/formatReefAmount';
-import { shortAddress, toCurrencyFormat } from '../../utils/utils';
+import { formatReefAmount, formatReefAmountPlain } from '../../utils/formatReefAmount';
+import { shortAddress, formatUSDCompact } from '../../utils/utils';
 import './validators.css';
 import StakingActions from './StakingActions';
 import {
@@ -164,13 +164,15 @@ const Validators = (): JSX.Element => {
       </div>
       {tab === 'actions' && selectedSigner && (
         <div className="validators-page__stake">
-          <Uik.Text type="title">
+          <Uik.Text type="lead" className="validators-page__stake-label">
             {strings.your_stake}
-            :
-            {formatReefAmount(new BN(nominatorStake))}
           </Uik.Text>
-          <Uik.Text type="title">
-            {toCurrencyFormat(stakeUsd, { maximumFractionDigits: 2 })}
+          <Uik.Text type="headline" className="dashboard__sub-balance-value validators-page__stake-amount">
+            {formatReefAmountPlain(new BN(nominatorStake))}
+            <Uik.ReefIcon />
+            <span className="validators-page__stake-usd">
+              ({formatUSDCompact(stakeUsd)})
+            </span>
           </Uik.Text>
         </div>
       )}

--- a/src/pages/validators/validators.css
+++ b/src/pages/validators/validators.css
@@ -26,6 +26,20 @@
   margin-bottom: 20px;
 }
 
+.validators-page__stake-label {
+  margin-bottom: 4px;
+}
+
+.validators-page__stake-amount {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.validators-page__stake-usd {
+  margin-left: 0.25rem;
+}
+
 .validators-page__nominations-list {
   list-style: none;
   padding-left: 0;

--- a/src/utils/formatReefAmount.ts
+++ b/src/utils/formatReefAmount.ts
@@ -22,3 +22,12 @@ export function formatReefAmount(value: BN): string {
   const cleaned = truncated.replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
   return `${cleaned}${units[unitIndex]} REEF`;
 }
+
+/**
+ * Format a value in Planck (18 decimals) into a human readable
+ * string in REEF with dynamic K/M/B suffix but without the ticker.
+ * The returned string is always in English and truncated to at most two decimals.
+ */
+export function formatReefAmountPlain(value: BN): string {
+  return formatReefAmount(value).replace(' REEF', '');
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -45,6 +45,11 @@ export const toHumanAmount = (amount: string): string => {
   return amount.slice(0, head.length + 4);
 };
 
+export const formatUSDCompact = (value: number): string => {
+  const formatted = toHumanAmount(value.toFixed(2));
+  return `$${formatted}`;
+};
+
 export const formatAgoDate = (timestamp: number|string): string => {
   const now = new Date(Date.now());
   const date = new Date(timestamp);


### PR DESCRIPTION
## Summary
- add `formatReefAmountPlain` to omit ticker
- add `formatUSDCompact` helper
- style validators stake section and display Reef + USD values

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684f00bed8d0832d8f0f1fada6f2169a