### PR TITLE
Add min nominator stake in validators table

### DIFF
--- a/src/pages/validators/Validators.tsx
+++ b/src/pages/validators/Validators.tsx
@@ -37,7 +37,6 @@ const Validators = (): JSX.Element => {
       return [];
     }
   });
-  const [selected, setSelected] = useState<string[]>([]);
   const [nominations, setNominations] = useState<string[]>([]);
   const [nominatorStake, setNominatorStake] = useState<string>('0');
   const stakeNumber = Number(ethUtils.formatUnits(nominatorStake || '0', 18));
@@ -75,12 +74,25 @@ const Validators = (): JSX.Element => {
               identity = display;
             }
           }
+          const others: any[] = (exposure as any)?.others || [];
+          let minStake = '0';
+          if (others.length) {
+            const sorted = others
+              .map((o) => new BN(o.value.toString()))
+              .sort((a, b) => b.cmp(a));
+            const idx = Math.min(sorted.length, 64) - 1;
+            if (idx >= 0) {
+              minStake = sorted[idx].toString();
+            }
+          }
+
           vals.push({
             address: addr,
             identity,
             totalBonded: (exposure as any)?.total?.toString() || '0',
             commission: prefs?.commission?.toString() || '0',
             isActive: overview.validators.includes(addr),
+            minNominatorStake: minStake,
           });
         }
         setValidators(vals);
@@ -134,15 +146,6 @@ const Validators = (): JSX.Element => {
     loadStake();
   }, [provider, selectedSigner]);
 
-  const toggleSelect = (addr: string): void => {
-    setSelected((prev) => {
-      const exists = prev.includes(addr);
-      if (exists) return prev.filter((a) => a !== addr);
-      if (prev.length >= 16) return prev;
-      return [...prev, addr];
-    });
-  };
-
   return (
     <div className="validators-page">
       <Uik.Text type="headline" className="validators-page__title">
@@ -195,9 +198,9 @@ const Validators = (): JSX.Element => {
       <Uik.Table seamless>
         <Uik.THead>
           <Uik.Tr>
-            <Uik.Th />
             <Uik.Th>{strings.account}</Uik.Th>
             <Uik.Th>{strings.total_staked}</Uik.Th>
+            <Uik.Th>Min required</Uik.Th>
             <Uik.Th>Commission</Uik.Th>
             <Uik.Th />
           </Uik.Tr>
@@ -206,19 +209,15 @@ const Validators = (): JSX.Element => {
           {validators.map((v) => (
             <Uik.Tr key={v.address}>
               <Uik.Td>
-                <input
-                  type="checkbox"
-                  checked={selected.includes(v.address)}
-                  onChange={() => toggleSelect(v.address)}
-                />
-              </Uik.Td>
-              <Uik.Td>
                 <div className="validators-page__id">
                   {v.identity ? v.identity : shortAddress(v.address)}
                 </div>
               </Uik.Td>
               <Uik.Td>
                 {formatReefAmount(new BN(v.totalBonded))}
+              </Uik.Td>
+              <Uik.Td>
+                {formatReefAmount(new BN(v.minNominatorStake || '0'))}
               </Uik.Td>
               <Uik.Td>
                 {(Number(v.commission) / 10000000).toFixed(2)}

--- a/src/utils/validatorsCache.ts
+++ b/src/utils/validatorsCache.ts
@@ -4,6 +4,7 @@ export interface CachedValidator {
   totalBonded: string;
   commission: string;
   isActive: boolean;
+  minNominatorStake?: string;
 }
 
 interface CacheEntry {


### PR DESCRIPTION
## Summary
- compute the smallest stake among the top nominators for each validator
- display that value as **Min required** in the validators table
- remove validator selection checkboxes

## Testing
- `yarn lint` *(fails: eslint errors across repo)*
- `CI=true yarn test --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0897ef00832d8e78c3175698c685