### PR TITLE
Add staking action modal

### DIFF
--- a/src/components/staking/BondActionModal.tsx
+++ b/src/components/staking/BondActionModal.tsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useState } from 'react';
+import { Components } from '@reef-chain/react-lib';
+import Uik from '@reef-chain/ui-kit';
+import { ApiPromise } from '@polkadot/api';
+import BN from 'bn.js';
+import { bnToBn } from '@polkadot/util';
+import { extension as reefExt } from '@reef-chain/util-lib';
+import PercentSlider from './PercentSlider';
+import './bond-action.css';
+import { localizedStrings as strings } from '../../l10n/l10n';
+
+const { OverlayAction } = Components;
+const { web3Enable, web3FromSource } = reefExt;
+const DECIMALS = new BN(10).pow(new BN(18));
+
+interface Props {
+  isOpen: boolean;
+  onClose(): void;
+  api: ApiPromise;
+  accountAddress: string;
+}
+
+export default function BondActionModal({ isOpen, onClose, api, accountAddress }: Props): JSX.Element {
+  const [tab, setTab] = useState<'bond' | 'unbond' | 'chill'>('bond');
+  const [availableBalance, setAvailableBalance] = useState<BN>(new BN(0));
+  const [stakedBalance, setStakedBalance] = useState<BN>(new BN(0));
+  const [amount, setAmount] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    let unsubBalance: () => void;
+
+    api.query.system
+      .account(accountAddress, (acc) => {
+        const free = new BN((acc.data as any).free.toString());
+        setAvailableBalance(free.div(DECIMALS));
+      })
+      .then((unsub) => {
+        unsubBalance = unsub;
+      })
+      .catch(() => {});
+
+    api.derive.staking
+      .account(accountAddress)
+      .then((info: any) => {
+        const active = new BN(info.stakingLedger?.active?.toString() || '0');
+        setStakedBalance(active.div(DECIMALS));
+      })
+      .catch(() => {});
+
+    (async () => {
+      try {
+        await web3Enable('reef-app');
+        const injector = await web3FromSource('polkadot-js');
+        api.setSigner(injector.signer);
+      } catch (e) {
+        // ignore
+      }
+    })();
+
+    return () => {
+      if (unsubBalance) unsubBalance();
+    };
+  }, [isOpen, api, accountAddress]);
+
+  const sendTx = async (extrinsic: any, success: string, error: string): Promise<void> => {
+    try {
+      setLoading(true);
+      await extrinsic.signAndSend(accountAddress, ({ status }: any) => {
+        if (status.isInBlock || status.isFinalized) {
+          Uik.notify.success(success);
+          setLoading(false);
+          onClose();
+        }
+      });
+    } catch (e) {
+      setLoading(false);
+      Uik.notify.danger(error);
+    }
+  };
+
+  const handleBond = (): void => {
+    const valueBN = bnToBn(amount).mul(DECIMALS);
+    sendTx(
+      api.tx.staking.bond(valueBN, 'Staked'),
+      strings.staking_bond_success,
+      strings.staking_bond_error,
+    );
+  };
+
+  const handleUnbond = (): void => {
+    const valueBN = bnToBn(amount).mul(DECIMALS);
+    sendTx(
+      api.tx.staking.unbond(valueBN),
+      strings.staking_unbond_success,
+      strings.staking_unbond_error,
+    );
+  };
+
+  const handleChill = (): void => {
+    sendTx(
+      api.tx.staking.chill(),
+      strings.staking_chill_success,
+      strings.staking_chill_error,
+    );
+  };
+
+  const maxValue = tab === 'bond' ? availableBalance.toNumber() : stakedBalance.toNumber();
+  const stakeNumber = stakedBalance.toNumber();
+
+  return (
+    <OverlayAction isOpen={isOpen} onClose={onClose} title={strings.staking_bond_unbond} className="overlay-swap">
+      <div className="uik-pool-actions pool-actions">
+        <Uik.Tabs
+          value={tab}
+          onChange={(v: string) => { setTab(v as 'bond' | 'unbond' | 'chill'); setAmount(0); }}
+          options={[
+            { value: 'bond', text: strings.staking_bond },
+            { value: 'unbond', text: strings.staking_unbond },
+            { value: 'chill', text: strings.staking_chill },
+          ]}
+        />
+        <div className="bond-action-wrapper">
+          <Uik.Card className="bond-action-card">
+            <div className="uik-pool-actions-token">
+              <div className="uik-pool-actions-token__token">
+                <div className="uik-pool-actions-token__select-wrapper">
+                  <Uik.ReefIcon />
+                  <span>REEF</span>
+                </div>
+                {tab !== 'chill' && (
+                  <div className="uik-pool-actions-token__value">
+                    <Uik.Input
+                      type="number"
+                      value={amount.toString()}
+                      min={0}
+                      max={maxValue}
+                      onInput={(e) =>
+                        setAmount(Number((e.target as HTMLInputElement).value))
+                      }
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          </Uik.Card>
+
+          {tab !== 'chill' && (
+            <Uik.Card className="bond-action-card">
+              <PercentSlider max={maxValue} value={amount} onChange={setAmount} />
+            </Uik.Card>
+          )}
+
+          <Uik.Card className="bond-action-card bond-action-card-button">
+            {tab === 'bond' && (
+              <Uik.Button
+                success
+                text={strings.staking_bond}
+                loading={loading}
+                disabled={stakeNumber > 0}
+                onClick={handleBond}
+              />
+            )}
+            {tab === 'unbond' && (
+              <Uik.Button
+                success
+                text={strings.staking_unbond}
+                loading={loading}
+                disabled={stakeNumber === 0}
+                onClick={handleUnbond}
+              />
+            )}
+            {tab === 'chill' && (
+              <Uik.Button
+                danger
+                text={strings.staking_chill}
+                loading={loading}
+                disabled={stakeNumber === 0}
+                onClick={handleChill}
+              />
+            )}
+          </Uik.Card>
+        </div>
+      </div>
+    </OverlayAction>
+  );
+}

--- a/src/components/staking/PercentSlider.tsx
+++ b/src/components/staking/PercentSlider.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Uik from '@reef-chain/ui-kit';
+
+interface Props {
+  max: number;
+  value: number;
+  onChange(value: number): void;
+}
+
+const PercentSlider = ({ max, value, onChange }: Props): JSX.Element => {
+  const percent = max === 0 ? 0 : Math.round((value / max) * 100);
+  const handleChange = (p: number): void => {
+    const newVal = Math.round((p / 100) * max);
+    onChange(newVal);
+  };
+  return (
+    <Uik.Slider
+      value={percent}
+      onChange={handleChange}
+      tooltip={`${percent}%`}
+      helpers={[
+        { position: 0, text: '0%' },
+        { position: 25, text: '25%' },
+        { position: 50, text: '50%' },
+        { position: 75, text: '75%' },
+        { position: 100, text: '100%' },
+      ]}
+    />
+  );
+};
+
+export default PercentSlider;

--- a/src/components/staking/bond-action.css
+++ b/src/components/staking/bond-action.css
@@ -1,0 +1,14 @@
+.bond-action-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+  margin-top: 20px;
+}
+.bond-action-card {
+  background: #E6E2F1;
+}
+.bond-action-card-button {
+  display: flex;
+  justify-content: center;
+}
+

--- a/src/pages/validators/Actions.tsx
+++ b/src/pages/validators/Actions.tsx
@@ -19,7 +19,7 @@ import {
   CachedValidator,
 } from '../../utils/validatorsCache';
 import './validators.css';
-import BondModal from '../../components/staking/BondModal';
+import BondActionModal from '../../components/staking/BondActionModal';
 
 const { OverlayAction } = Components;
 
@@ -184,7 +184,7 @@ const Actions: React.FC = () => {
           </Uik.TBody>
         </Uik.Table>
       </OverlayAction>
-      <BondModal
+      <BondActionModal
         isOpen={isBondOpen}
         onClose={() => setBondOpen(false)}
         api={provider?.api as ApiPromise}


### PR DESCRIPTION
## Summary
- create `BondActionModal` with Bond/Unbond/Chill tabs
- add reusable `PercentSlider`
- use new modal in validators page
- fix input type and remove unsupported Card prop
- adjust staking modal spacing and button logic
- fix bond extrinsic call and add spacing between tabs and cards

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68515a11e430832dbbc39921cd15f71c