### PR TITLE
Add staking withdraw option

### DIFF
--- a/src/components/staking/bond-action.css
+++ b/src/components/staking/bond-action.css
@@ -10,5 +10,19 @@
 .bond-action-card-button {
   display: flex;
   justify-content: center;
+  align-items: center;
+  gap: 15px;
+  width: 100%;
+}
+
+/* Increase width of amount input */
+.bond-action-card .uik-input__input {
+  width: 18ch;
+}
+
+
+.bond-action-warning {
+  text-align: center;
+  color: #e74c3c;
 }
 

--- a/src/l10n/l10n.tsx
+++ b/src/l10n/l10n.tsx
@@ -113,6 +113,10 @@ export const localizedStrings = new LocalizedStrings({
     staking_unbond_error: 'Unbond failed',
     staking_chill_success: 'Chill submitted',
     staking_chill_error: 'Chill failed',
+    staking_withdraw_success: 'Withdraw submitted',
+    staking_withdraw_error: 'Withdraw failed',
+    staking_tab: 'Staking',
+    staking_fees_warning: 'Leave at least 10 REEF for fees',
   },
   hi: {
     bonds: 'बॉन्ड',
@@ -223,6 +227,10 @@ export const localizedStrings = new LocalizedStrings({
     staking_unbond_error: 'अनबॉन्ड असफल',
     staking_chill_success: 'चिल भेजा गया',
     staking_chill_error: 'चिल असफल',
+    staking_withdraw_success: 'निकासी भेजी गई',
+    staking_withdraw_error: 'निकासी विफल',
+    staking_tab: 'स्टेकिंग',
+    staking_fees_warning: 'कृपया फीस के लिए कम से कम 10 रीफ छोड़ें',
   },
 });
 


### PR DESCRIPTION
## Summary
- center staking action buttons and enlarge input width
- add withdraw button that appears after unbonding
- introduce new `Staking` tab in staking modal
- update translations for withdraw and staking
- rename staking tab button and enforce fee reserve for staking
- fix missing argument for `withdrawUnbonded` and enlarge input field
- fix staking slider component and adjust button centering
- restore original UI kit slider component for both tabs

## Testing
- `yarn test --watchAll=false --passWithNoTests` *(fails: package not present in lockfile)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685312233a10832d9f098a48a5a2fc7b