### PR TITLE
Implement independent staking sliders

### DIFF
--- a/src/components/staking/tabs/BondTab.tsx
+++ b/src/components/staking/tabs/BondTab.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import Uik from '@reef-chain/ui-kit';
+import BN from 'bn.js';
+import PercentSlider from '../PercentSlider';
+import { localizedStrings as strings } from '../../../l10n/l10n';
+
+interface Props {
+  bondAmount: number;
+  setBondAmount(value: number): void;
+  bondMaxValue: number;
+  stakeNumber: number;
+  loading: boolean;
+  handleBond(): void;
+  handleUnbond(): void;
+  redeemableBalance: BN;
+  remainingEras: number | null;
+  withdrawText: string;
+  handleWithdraw(): void;
+}
+
+export default function BondTab({
+  bondAmount,
+  setBondAmount,
+  bondMaxValue,
+  stakeNumber,
+  loading,
+  handleBond,
+  handleUnbond,
+  redeemableBalance,
+  remainingEras,
+  withdrawText,
+  handleWithdraw,
+}: Props): JSX.Element {
+  return (
+    <div className="bond-action-wrapper">
+      <Uik.Card className="bond-action-card">
+        <div className="uik-pool-actions-token">
+          <div className="uik-pool-actions-token__token">
+            <div className="uik-pool-actions-token__select-wrapper">
+              <Uik.ReefIcon />
+              <span>REEF</span>
+            </div>
+            <div className="uik-pool-actions-token__value">
+              <Uik.Input
+                type="number"
+                value={bondAmount.toString()}
+                min={0}
+                max={bondMaxValue}
+                onInput={(e) =>
+                  setBondAmount(Number((e.target as HTMLInputElement).value))
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </Uik.Card>
+      <Uik.Card className="bond-action-card">
+        <PercentSlider
+          max={bondMaxValue}
+          value={bondAmount}
+          onChange={setBondAmount}
+        />
+      </Uik.Card>
+      <Uik.Card className="bond-action-card bond-action-card-button">
+        <>
+          <Uik.Button
+            success
+            text={stakeNumber === 0 ? strings.staking_bond : strings.staking_unbond}
+            loading={loading}
+            onClick={stakeNumber === 0 ? handleBond : handleUnbond}
+          />
+          {(redeemableBalance.gt(new BN(0)) || (remainingEras && remainingEras > 0)) && (
+            <Uik.Button
+              success
+              text={withdrawText}
+              loading={loading}
+              disabled={!redeemableBalance.gt(new BN(0))}
+              onClick={handleWithdraw}
+            />
+          )}
+        </>
+      </Uik.Card>
+    </div>
+  );
+}

--- a/src/components/staking/tabs/ChillTab.tsx
+++ b/src/components/staking/tabs/ChillTab.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Uik from '@reef-chain/ui-kit';
+import { localizedStrings as strings } from '../../../l10n/l10n';
+
+interface Props {
+  stakeNumber: number;
+  loading: boolean;
+  handleChill(): void;
+}
+
+export default function ChillTab({
+  stakeNumber,
+  loading,
+  handleChill,
+}: Props): JSX.Element {
+  return (
+    <div className="bond-action-wrapper">
+      <Uik.Card className="bond-action-card bond-action-card-button">
+        <Uik.Button
+          danger
+          text={strings.staking_chill}
+          loading={loading}
+          disabled={stakeNumber === 0}
+          onClick={handleChill}
+        />
+      </Uik.Card>
+    </div>
+  );
+}

--- a/src/components/staking/tabs/StakingTab.tsx
+++ b/src/components/staking/tabs/StakingTab.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import Uik from '@reef-chain/ui-kit';
+import PercentSlider from '../PercentSlider';
+import { localizedStrings as strings } from '../../../l10n/l10n';
+
+interface Props {
+  stakeAmount: number;
+  setStakeAmount(value: number): void;
+  stakingMaxValue: number;
+  loading: boolean;
+  handleStake(): void;
+}
+
+export default function StakingTab({
+  stakeAmount,
+  setStakeAmount,
+  stakingMaxValue,
+  loading,
+  handleStake,
+}: Props): JSX.Element {
+  return (
+    <div className="bond-action-wrapper">
+      <Uik.Card className="bond-action-card">
+        <div className="uik-pool-actions-token">
+          <div className="uik-pool-actions-token__token">
+            <div className="uik-pool-actions-token__select-wrapper">
+              <Uik.ReefIcon />
+              <span>REEF</span>
+            </div>
+            <div className="uik-pool-actions-token__value">
+              <Uik.Input
+                type="number"
+                value={stakeAmount.toString()}
+                min={0}
+                max={stakingMaxValue}
+                onInput={(e) =>
+                  setStakeAmount(Number((e.target as HTMLInputElement).value))
+                }
+              />
+            </div>
+          </div>
+        </div>
+      </Uik.Card>
+      <Uik.Card className="bond-action-card">
+        <PercentSlider
+          max={stakingMaxValue}
+          value={stakeAmount}
+          onChange={setStakeAmount}
+        />
+      </Uik.Card>
+      <Uik.Text type="mini" className="bond-action-warning">
+        {strings.staking_fees_warning}
+      </Uik.Text>
+      <Uik.Card className="bond-action-card bond-action-card-button">
+        <Uik.Button
+          success
+          text={strings.stake}
+          loading={loading}
+          onClick={handleStake}
+        />
+      </Uik.Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow separate amounts for Bond/Unbond and Staking sliders
- base Bond slider on available or staked balance
- show withdraw button with remaining eras
- split Bond, Staking and Chill tabs into separate components

## Testing
- `yarn build`
- `yarn test --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_685320a9223c832db08a7fbc2468d7fb