### PR TITLE
Fix bond slider using dashboard balances

### DIFF
--- a/src/components/staking/tabs/BondTab.tsx
+++ b/src/components/staking/tabs/BondTab.tsx
@@ -7,7 +7,8 @@ import { localizedStrings as strings } from '../../../l10n/l10n';
 interface Props {
   bondAmount: number;
   setBondAmount(value: number): void;
-  bondMaxValue: number;
+  availableAmount: number;
+  lockedAmount: number;
   stakeNumber: number;
   loading: boolean;
   handleBond(): void;
@@ -21,7 +22,8 @@ interface Props {
 export default function BondTab({
   bondAmount,
   setBondAmount,
-  bondMaxValue,
+  availableAmount,
+  lockedAmount,
   stakeNumber,
   loading,
   handleBond,
@@ -31,6 +33,7 @@ export default function BondTab({
   withdrawText,
   handleWithdraw,
 }: Props): JSX.Element {
+  const maxValue = stakeNumber === 0 ? availableAmount : lockedAmount;
   return (
     <div className="bond-action-wrapper">
       <Uik.Card className="bond-action-card">
@@ -45,7 +48,7 @@ export default function BondTab({
                 type="number"
                 value={bondAmount.toString()}
                 min={0}
-                max={bondMaxValue}
+                max={maxValue}
                 onInput={(e) =>
                   setBondAmount(Number((e.target as HTMLInputElement).value))
                 }
@@ -56,7 +59,7 @@ export default function BondTab({
       </Uik.Card>
       <Uik.Card className="bond-action-card">
         <PercentSlider
-          max={bondMaxValue}
+          max={maxValue}
           value={bondAmount}
           onChange={setBondAmount}
         />


### PR DESCRIPTION
## Summary
- adapt BondTab slider max to available vs locked balance
- read available and staked amounts from `ReefSigners` context instead of direct API calls

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*
- `npx tsc --noEmit` *(fails: Cannot find module 'ethers' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68532e9d84ec832dadd530c5d3ba4ac7