### PR TITLE
Update validators header layout

### DIFF
--- a/src/pages/validators/Actions.tsx
+++ b/src/pages/validators/Actions.tsx
@@ -184,20 +184,29 @@ const Actions: React.FC = () => {
   return (
     <div>
       {selectedSigner && (
-        <div className="validators-page__stake">
-          <Uik.Text type="lead" className="uik-text--lead">{strings.your_stake}</Uik.Text>
-          <Uik.Text type="headline" className="dashboard__sub-balance-value">
-            <span className="dashboard__balance-text">{formattedStake}</span>
-            <Uik.ReefIcon />
-            <span className="validators-page__stake-usd">
-              (
-              {formattedStakeUsd}
-              )
-            </span>
-          </Uik.Text>
-          <Uik.Button text="My nominations" fill onClick={() => setNominationsOpen(true)} />
-          <Uik.Button text={strings.staking_bond_unbond} fill onClick={() => setBondOpen(true)} />
-        </div>
+        <>
+          <div className="validators-page__stake-info">
+            <Uik.Text type="lead" className="uik-text--lead">{strings.your_stake}</Uik.Text>
+            <Uik.Text type="headline" className="dashboard__sub-balance-value">
+              <span className="dashboard__balance-text">{formattedStake}</span>
+              <Uik.ReefIcon />
+              <span className="validators-page__stake-usd">
+                (
+                {formattedStakeUsd}
+                )
+              </span>
+            </Uik.Text>
+          </div>
+          <div className="validators-page__actions">
+            <Uik.Button text="My nominations" fill onClick={() => setNominationsOpen(true)} />
+            <Uik.Button
+              text={strings.staking_bond_unbond}
+              fill
+              onClick={() => setBondOpen(true)}
+              className="bond-button"
+            />
+          </div>
+        </>
       )}
       <OverlayAction
         isOpen={isNominationsOpen}

--- a/src/pages/validators/Actions.tsx
+++ b/src/pages/validators/Actions.tsx
@@ -203,7 +203,6 @@ const Actions: React.FC = () => {
               text={strings.staking_bond_unbond}
               fill
               onClick={() => setBondOpen(true)}
-              className="bond-button"
             />
           </div>
         </>

--- a/src/pages/validators/Validators.tsx
+++ b/src/pages/validators/Validators.tsx
@@ -1,36 +1,18 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Uik from '@reef-chain/ui-kit';
-import { useHistory } from 'react-router-dom';
 import { localizedStrings as strings } from '../../l10n/l10n';
-import { VALIDATORS_URL } from '../../urls';
 import Active from './Active';
 import Actions from './Actions';
 import './validators.css';
 
 const Validators = (): JSX.Element => {
-  const history = useHistory();
-  const [tab, setTab] = useState<'active' | 'actions'>('active');
-
   return (
     <div className="validators-page">
       <Uik.Text type="headline" className="validators-page__title">
         {strings.validators}
       </Uik.Text>
-      <div className="validators-page__filter">
-        <Uik.Tabs
-          value={tab}
-          onChange={(val) => {
-            const t = val as 'active' | 'actions';
-            setTab(t);
-            if (t === 'active') history.push(VALIDATORS_URL);
-          }}
-          options={[
-            { value: 'active', text: 'Active' },
-            { value: 'actions', text: 'Actions' },
-          ]}
-        />
-      </div>
-      {tab === 'active' ? <Active /> : <Actions />}
+      <Actions />
+      <Active />
     </div>
   );
 };

--- a/src/pages/validators/validators.css
+++ b/src/pages/validators/validators.css
@@ -29,11 +29,14 @@
   gap: 0.25rem;
 }
 
-.validators-page__stake {
-  margin-bottom: 20px;
+.validators-page__stake-info {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-bottom: 10px;
 }
 
-.validators-page__stake .uik-reef-icon {
+.validators-page__stake-info .uik-reef-icon {
   height: 1em;
   width: 1em;
   margin-left: 0.25rem;
@@ -60,6 +63,16 @@
   display: flex;
   justify-content: flex-end;
   margin-bottom: 10px;
+}
+
+.validators-page__actions {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 20px;
+}
+
+.validators-page__actions .bond-button {
+  margin-left: auto;
 }
 
 .dashboard__balance-text {

--- a/src/pages/validators/validators.css
+++ b/src/pages/validators/validators.css
@@ -67,12 +67,9 @@
 
 .validators-page__actions {
   display: flex;
-  gap: 1rem;
+  justify-content: flex-end;
+  gap: 0.5rem;
   margin-bottom: 20px;
-}
-
-.validators-page__actions .bond-button {
-  margin-left: auto;
 }
 
 .dashboard__balance-text {


### PR DESCRIPTION
## Summary
- remove tab switching on validators page
- show stake info and staking buttons directly in validators page
- style new validators header layout

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6854707eb0f0832db4eeb41f5971eb30