### PR TITLE
feat: toggle waiting validators

### DIFF
--- a/src/l10n/l10n.tsx
+++ b/src/l10n/l10n.tsx
@@ -117,6 +117,7 @@ export const localizedStrings = new LocalizedStrings({
     staking_withdraw_error: 'Withdraw failed',
     staking_tab: 'Staking',
     staking_fees_warning: 'Leave at least 10 REEF for fees',
+    show_waiting_validators: 'Show waiting validators',
   },
   hi: {
     bonds: 'बॉन्ड',
@@ -231,6 +232,7 @@ export const localizedStrings = new LocalizedStrings({
     staking_withdraw_error: 'निकासी विफल',
     staking_tab: 'स्टेकिंग',
     staking_fees_warning: 'कृपया फीस के लिए कम से कम 10 रीफ छोड़ें',
+    show_waiting_validators: 'वेटिंग वैलिडेटरों को दिखाएँ',
   },
 });
 

--- a/src/pages/validators/validators.css
+++ b/src/pages/validators/validators.css
@@ -75,3 +75,10 @@
 .dashboard__balance-text {
   display: inline-flex;
 }
+
+.my-nominations__show-waiting {
+  --border-color: var(--text);
+  --border-color--h: var(--text--h);
+  --border-color--s: var(--text--s);
+  --border-color--l: var(--text--l);
+}


### PR DESCRIPTION
## Summary
- reload validator list to include waiting set when checkbox is toggled
- use Uik.Checkbox to show/hide waiting validators
- darken checkbox border so it remains visible against modal background

## Testing
- `npx eslint src/pages/validators/Actions.tsx src/l10n/l10n.tsx`
- `CI=true npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689a1c04d274832d83dd66c5663f0a6f